### PR TITLE
Introduce chialab/proteins

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -11,7 +11,8 @@
  */
 export * from './src/core.js';
 
-import { mix, MIXINS } from './src/core.js';
+import { mix } from '@chialab/proteins';
+import { MIXINS } from './src/core.js';
 import { registry } from './src/lib/registry.js';
 import { proxy } from './src/lib/proxy.js';
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/chialab/dna#readme",
   "dependencies": {
-    "@chialab/proteins": "^3.0.0-rc.5"
+    "@chialab/proteins": "^3.0.0-rc.6"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/chialab/dna/issues"
   },
-  "homepage": "https://github.com/chialab/dna#readme"
+  "homepage": "https://github.com/chialab/dna#readme",
+  "dependencies": {
+    "@chialab/proteins": "^3.0.0-rc.5"
+  }
 }

--- a/packages/core/src/core.js
+++ b/packages/core/src/core.js
@@ -24,5 +24,5 @@ export const MIXINS = {
     StyleMixin,
     TemplateMixin,
 };
-export { mix } from './lib/mixins.js';
+export { mix } from '@chialab/proteins';
 export { prop } from './lib/property.js';

--- a/packages/core/src/lib/dispatch.js
+++ b/packages/core/src/lib/dispatch.js
@@ -1,4 +1,4 @@
-import { isString } from './typeof.js';
+import { isString } from '@chialab/proteins';
 import { CustomEvent } from '../helpers/custom-event.js';
 
 /**

--- a/packages/core/src/lib/dom.js
+++ b/packages/core/src/lib/dom.js
@@ -1,4 +1,4 @@
-import { isFunction, isString } from './typeof.js';
+import { isFunction, isString } from '@chialab/proteins';
 import { registry } from './registry.js';
 import { DNA_SYMBOL, COMPONENT_SYMBOL } from './symbols.js';
 

--- a/packages/core/src/lib/mixins.js
+++ b/packages/core/src/lib/mixins.js
@@ -1,64 +1,7 @@
-import { reduce } from '../helpers/arr-reduce.js';
-
 /**
- * A Mixin helper class.
- * @ignore
+ * Proxy to `mixin.js` of @chialab/proteins`.
+ * It is maintained for backward compatibility but you should use `@chialab/proteins` instead.
+ *
+ * @deprecated since 2.8.0
  */
-class Mixin {
-    /**
-     * Create a mixable class.
-     * @param {Function} superClass The class to extend.
-     */
-    constructor(superclass) {
-        superclass = superclass || class {};
-        this.superclass = superclass;
-    }
-    /**
-     * Mix the super class with a list of mixins.
-     * @param {...Function} mixins *N* mixin functions.
-     * @return {Function} The extended class.
-     */
-    with() {
-        // eslint-disable-next-line
-        let args = [].slice.call(arguments, 0);
-        return reduce(args, (c, mixin) => mixin(c), this.superclass);
-    }
-}
-
-/**
- * Mix a class with a mixin.
- * @author Justin Fagnani (https://github.com/justinfagnani)
- * @memberof DNA
- *
- * @param {Function} superClass The class to extend.
- * @return {Function} A mixed class.
- *
- * @example
- * ```js
- * // my-super.js
- * export class MySuperClass {
- *     constructor() {
- *         // do something
- *     }
- * }
- * ```
- * ```js
- * // mixin.js
- * export const Mixin = (superClass) => class extends superClass {
- *     constructor() {
- *         super();
- *         // do something else
- *     }
- * };
- * ```
- * ```js
- * import { mix } from '@dnajs/core';
- * import { MySuperClass } from './my-super.js';
- * import { Mixin } from './mixin.js';
- *
- * export class MixedClass extends mix(MySuperClass).with(Mixin) {
- *     ...
- * }
- * ```
- */
-export const mix = (superClass) => new Mixin(superClass);
+export { mix } from '@chialab/proteins';

--- a/packages/core/src/lib/property.js
+++ b/packages/core/src/lib/property.js
@@ -1,4 +1,4 @@
-import { isUndefined, isFunction, isArray, isObject, isString } from './typeof.js';
+import { isUndefined, isFunction, isArray, isObject, isString } from '@chialab/proteins';
 import { define } from '../helpers/obj-define.js';
 
 /**

--- a/packages/core/src/lib/typeof.js
+++ b/packages/core/src/lib/typeof.js
@@ -1,66 +1,17 @@
 /**
- * Check if an value is a function.
- * @method isFunction
- * @private
+ * Proxy to `type.js` of @chialab/proteins`.
+ * It is maintained for backward compatibility but you should use `@chialab/proteins` instead.
  *
- * @param {*} obj The value to check.
- * @return {Boolean}
+ * @deprecated since 2.8.0
  */
-export function isFunction(obj) {
-    return typeof obj === 'function';
-}
-/**
- * Check if an value is a string.
- * @method isString
- * @private
- *
- * @param {*} obj The value to check.
- * @return {Boolean}
- */
-export function isString(obj) {
-    return typeof obj === 'string';
-}
-/**
- * Check if an value is an object.
- * @method isObject
- * @private
- *
- * @param {*} obj The value to check.
- * @return {Boolean}
- */
-export function isObject(obj) {
-    return Object.prototype.toString.call(obj) === '[object Object]';
-}
-/**
- * Check if an value is undefined.
- * @method isUndefined
- * @private
- *
- * @param {*} obj The value to check.
- * @return {Boolean}
- */
-export function isUndefined(obj) {
-    return typeof obj === 'undefined';
-}
-/**
- * Check if an value is an array.
- * @method isArray
- * @private
- *
- * @param {*} obj The value to check.
- * @return {Boolean}
- */
-export function isArray(obj) {
-    return Array.isArray(obj);
-}
-/**
- * Check if falsy value.
- * @method isFalsy
- * @private
- *
- * @param {*} obj The value to check.
- * @return {Boolean}
- */
-export function isFalsy(obj) {
-    return isUndefined(obj) || obj === null || obj === false;
-}
+export {
+    isFunction,
+    isString,
+    isNumber,
+    isBoolean,
+    isDate,
+    isObject,
+    isUndefined,
+    isArray,
+    isFalsy,
+} from '@chialab/proteins';

--- a/packages/core/src/mixins/events-component.js
+++ b/packages/core/src/mixins/events-component.js
@@ -1,6 +1,6 @@
+import { isString, isFunction } from '@chialab/proteins';
 import { define } from '../helpers/obj-define.js';
 import { reduceObjectProperty } from '../lib/reduce.js';
-import { isString, isFunction } from '../lib/typeof.js';
 import { matches } from '../helpers/matches.js';
 import { dispatch } from '../lib/dispatch.js';
 

--- a/packages/core/src/mixins/properties-component.js
+++ b/packages/core/src/mixins/properties-component.js
@@ -1,6 +1,6 @@
+import { isFalsy, isUndefined } from '@chialab/proteins';
 import { define } from '../helpers/obj-define.js';
 import { reduceObjectProperty } from '../lib/reduce.js';
-import { isFalsy, isUndefined } from '../lib/typeof.js';
 import { dispatch } from '../lib/dispatch.js';
 import { prop, Property } from '../lib/property.js';
 

--- a/packages/core/src/mixins/style-component.js
+++ b/packages/core/src/mixins/style-component.js
@@ -1,6 +1,6 @@
+import { isString } from '@chialab/proteins';
 import { define } from '../helpers/obj-define.js';
 import { reduceProperty } from '../lib/reduce.js';
-import { isString } from '../lib/typeof.js';
 import { convertShadowCSS } from '../lib/shadow-css.js';
 import { STYLE_SYMBOL } from '../lib/symbols.js';
 

--- a/packages/core/src/mixins/template-component.js
+++ b/packages/core/src/mixins/template-component.js
@@ -1,4 +1,4 @@
-import { isUndefined, isFunction, isFalsy } from '../lib/typeof.js';
+import { isUndefined, isFunction, isFalsy } from '@chialab/proteins';
 
 /**
  * Simple Custom Component with template handling using the `template` property.

--- a/packages/core/test/components/style.js
+++ b/packages/core/test/components/style.js
@@ -1,5 +1,5 @@
+import { isFunction } from '@chialab/proteins';
 import { BaseComponent } from '../../index.js';
-import { isFunction } from '../../src/lib/typeof.js';
 
 class TestComponent extends BaseComponent {
     get template() {

--- a/packages/core/test/unit/lib.js
+++ b/packages/core/test/unit/lib.js
@@ -7,7 +7,7 @@ import {
     isUndefined,
     isArray,
     isFalsy,
-} from '../../src/lib/typeof.js';
+} from '@chialab/proteins';
 import * as DOM from '../../src/lib/dom.js';
 import { render } from '../../src/lib/render.js';
 import { define } from '../../src/lib/define.js';

--- a/packages/custom-elements-v0/index.js
+++ b/packages/custom-elements-v0/index.js
@@ -6,7 +6,8 @@
  * Evolution-based components.
  * Use with Custom Elements v0 spec.
  */
-import { mix, MIXINS } from '@dnajs/core/src/core.js';
+import { mix } from '@chialab/proteins';
+import { MIXINS } from '@dnajs/core/src/core.js';
 import * as IDOM from '@dnajs/idom/src/lib/idom.js';
 import { registry } from '@dnajs/core/src/lib/registry.js';
 import { IDOMMixin } from '@dnajs/idom/src/mixins/idom.js';

--- a/packages/custom-elements-v0/package.json
+++ b/packages/custom-elements-v0/package.json
@@ -16,6 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@chialab/proteins": "^3.0.0-rc.5",
     "@dnajs/core": "^2.7.4",
     "@dnajs/idom": "^2.7.4"
   },

--- a/packages/custom-elements-v0/package.json
+++ b/packages/custom-elements-v0/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@chialab/proteins": "^3.0.0-rc.5",
+    "@chialab/proteins": "^3.0.0-rc.6",
     "@dnajs/core": "^2.7.4",
     "@dnajs/idom": "^2.7.4"
   },

--- a/packages/custom-elements-v0/src/lib/bind.js
+++ b/packages/custom-elements-v0/src/lib/bind.js
@@ -1,4 +1,4 @@
-import { isFunction } from '@dnajs/core/src/lib/typeof.js';
+import { isFunction } from '@chialab/proteins';
 import { define } from '@dnajs/core/src/helpers/obj-define.js';
 import { registry } from '@dnajs/core/src/lib/registry.js';
 

--- a/packages/custom-elements-v0/src/lib/shim.js
+++ b/packages/custom-elements-v0/src/lib/shim.js
@@ -1,4 +1,4 @@
-import { isString } from '@dnajs/core/src/lib/typeof.js';
+import { isString } from '@chialab/proteins';
 import { registry } from '@dnajs/core/src/lib/registry.js';
 
 /**

--- a/packages/custom-elements-v1/index.js
+++ b/packages/custom-elements-v1/index.js
@@ -6,10 +6,11 @@
  * Evolution-based components.
  * Use with Custom Elements spec.
  */
-import './src/lib/observer.js';
-import { mix, MIXINS } from '@dnajs/core/src/core.js';
+import { mix } from '@chialab/proteins';
+import { MIXINS } from '@dnajs/core/src/core.js';
 import * as IDOM from '@dnajs/idom/src/lib/idom.js';
 import { IDOMMixin } from '@dnajs/idom/src/mixins/idom.js';
+import './src/lib/observer.js';
 import { CustomElementMixin } from './src/mixins/custom-element.js';
 import { shim } from './src/lib/shim.js';
 

--- a/packages/idom/index.js
+++ b/packages/idom/index.js
@@ -6,11 +6,12 @@
  * Evolution-based components.
  * Use with IncrementalDOM templates.
  */
+import { mix } from '@chialab/proteins';
+import { MIXINS } from '@dnajs/core/src/core.js';
+import { proxy } from '@dnajs/core/src/lib/proxy.js';
 import './src/lib/observer.js';
 import * as IDOM from './src/lib/idom.js';
 import { IDOMMixin } from './src/mixins/idom.js';
-import { mix, MIXINS } from '@dnajs/core/src/core.js';
-import { proxy } from '@dnajs/core/src/lib/proxy.js';
 
 MIXINS.IDOMMixin = IDOMMixin;
 

--- a/packages/idom/package.json
+++ b/packages/idom/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@chialab/proteins": "^3.0.0-rc.5",
+    "@chialab/proteins": "^3.0.0-rc.6",
     "@dnajs/core": "^2.7.4",
     "incremental-dom": "^0.5.1"
   },

--- a/packages/idom/package.json
+++ b/packages/idom/package.json
@@ -16,6 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@chialab/proteins": "^3.0.0-rc.5",
     "@dnajs/core": "^2.7.4",
     "incremental-dom": "^0.5.1"
   },

--- a/packages/idom/src/lib/idom.js
+++ b/packages/idom/src/lib/idom.js
@@ -1,4 +1,4 @@
-import { isFalsy, isObject, isFunction, isArray, isString } from '@dnajs/core/src/lib/typeof.js';
+import { isFalsy, isObject, isFunction, isArray, isString } from '@chialab/proteins';
 import { DOM } from '@dnajs/core/src/core.js';
 import { registry } from '@dnajs/core/src/lib/registry.js';
 import {

--- a/packages/idom/src/lib/observer.js
+++ b/packages/idom/src/lib/observer.js
@@ -1,7 +1,7 @@
 import { symbols, attributes, notifications } from 'incremental-dom/index.js';
+import { isFalsy } from '@chialab/proteins';
 import { DOM } from '@dnajs/core/src/core.js';
 import { registry } from '@dnajs/core/src/lib/registry.js';
-import { isFalsy } from '@dnajs/core/src/lib/typeof.js';
 import { patch } from './idom.js';
 
 const _created = notifications.nodesCreated;

--- a/packages/idom/src/mixins/idom.js
+++ b/packages/idom/src/mixins/idom.js
@@ -1,4 +1,4 @@
-import { isFunction } from '@dnajs/core/src/lib/typeof.js';
+import { isFunction } from '@chialab/proteins';
 import { patch } from '../lib/idom.js';
 
 export const IDOMMixin = (superClass) => class extends superClass {

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -7,7 +7,8 @@
  * Use with React.
  */
 import React from 'react';
-import { mix, MIXINS } from '@dnajs/core/src/core.js';
+import { mix } from '@chialab/proteins';
+import { MIXINS } from '@dnajs/core/src/core.js';
 import { registry } from '@dnajs/core/src/lib/registry.js';
 import { proxy } from '@dnajs/core/src/lib/proxy.js';
 import { ReactMixin } from './src/mixins/react.js';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,6 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@chialab/proteins": "^3.0.0-rc.5",
     "@dnajs/core": "^2.7.4",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@chialab/proteins": "^3.0.0-rc.5",
+    "@chialab/proteins": "^3.0.0-rc.6",
     "@dnajs/core": "^2.7.4",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"

--- a/packages/react/src/mixins/react.js
+++ b/packages/react/src/mixins/react.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { isFunction } from '@chialab/proteins';
 import { DOM } from '@dnajs/core/src/core.js';
-import { isFunction } from '@dnajs/core/src/lib/typeof.js';
 
 function convertProps(elem) {
     let res = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@chialab/proteins@^3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.npmjs.org/@chialab/proteins/-/proteins-3.0.0-rc.5.tgz#1b53b39ec70be2087249ad9a4dddc2007f51c3c4"
+"@chialab/proteins@^3.0.0-rc.6":
+  version "3.0.0-rc.6"
+  resolved "https://registry.npmjs.org/@chialab/proteins/-/proteins-3.0.0-rc.6.tgz#90720cdb7879326f8b443e9b692d8563c562e60e"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@chialab/proteins@^3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.npmjs.org/@chialab/proteins/-/proteins-3.0.0-rc.5.tgz#1b53b39ec70be2087249ad9a4dddc2007f51c3c4"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"


### PR DESCRIPTION
This PR resolve #35 replacing `typeof.js` and `mixins.js` with the implementation done in chialab/proteins.