### PR TITLE
feat: boolean property validation on sync

### DIFF
--- a/packages/core/src/mixins/properties-component.js
+++ b/packages/core/src/mixins/properties-component.js
@@ -13,7 +13,7 @@ import { prop, Property } from '../lib/property.js';
  * @return {*} The parsed value.
  */
 function getValue(property, attrVal) {
-    if (attrVal === '' && property.accepts(Boolean)) {
+    if ((attrVal === '' || property.name === attrVal) && property.accepts(Boolean)) {
         return true;
     }
     if (!property.accepts(String)) {

--- a/packages/core/src/mixins/properties-component.js
+++ b/packages/core/src/mixins/properties-component.js
@@ -13,7 +13,7 @@ import { prop, Property } from '../lib/property.js';
  * @return {*} The parsed value.
  */
 function getValue(property, attrVal) {
-    if ((attrVal === '' || property.name === attrVal) && property.accepts(Boolean)) {
+    if ((attrVal === '' || ((property.attrName || property.name) === attrVal)) && property.accepts(Boolean)) {
         return true;
     }
     if (!property.accepts(String)) {

--- a/packages/core/test/components/properties.js
+++ b/packages/core/test/components/properties.js
@@ -11,7 +11,7 @@ class TestComponent extends BaseComponent {
 
 export class TestComponent1 extends TestComponent {
     static get observedAttributes() {
-        return ['name', 'last-name', 'married', 'age', 'var'];
+        return ['name', 'last-name', 'married', 'age', 'var', 'validbool'];
     }
 
     get properties() {
@@ -24,6 +24,7 @@ export class TestComponent1 extends TestComponent {
                 .observe('onAgeChanged'),
             var: prop.STRING.attribute(),
             type: prop.NUMBER.default(2),
+            validbool: prop.STRING.attribute('validbool'),
         };
     }
 

--- a/packages/core/test/components/properties.js
+++ b/packages/core/test/components/properties.js
@@ -24,7 +24,7 @@ export class TestComponent1 extends TestComponent {
                 .observe('onAgeChanged'),
             var: prop.STRING.attribute(),
             type: prop.NUMBER.default(2),
-            validbool: prop.STRING.attribute('validbool'),
+            validbool: prop.BOOLEAN.attribute('validbool'),
         };
     }
 

--- a/packages/core/test/units/properties.js
+++ b/packages/core/test/units/properties.js
@@ -32,6 +32,13 @@ describe('PropertiesComponent', () => {
             elem.age = undefined;
             assert.equal(elem.age, undefined);
         });
+
+        it('should accept string value as boolean when string equals property name or empty string', () => {
+            elem.validbool = 'validbool';
+            assert.equal(elem.validbool, 'validbool');
+            elem.validbool = '';
+            assert.equal(elem.validbool, '');
+        });
     });
     describe('handle properties on initialization', () => {
         const elem = render(WRAPPER, TestComponent1, {

--- a/packages/core/test/units/properties.js
+++ b/packages/core/test/units/properties.js
@@ -34,10 +34,8 @@ describe('PropertiesComponent', () => {
         });
 
         it('should accept string value as boolean when string equals property name or empty string', () => {
-            elem.validbool = 'validbool';
-            assert.equal(elem.validbool, 'validbool');
-            elem.validbool = '';
-            assert.equal(elem.validbool, '');
+            DOM.setAttribute(elem, 'validbool', 'validbool');
+            assert.equal(elem.validbool, true);
         });
     });
     describe('handle properties on initialization', () => {


### PR DESCRIPTION
This provides a different validation for boolean properties, on sync of initial attributes with properties.
A property is considered a valid boolean when its `value` equals `property.name`.