### PR TITLE
Expose JSDOM instance in NodeJS environment

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -1,12 +1,16 @@
 import jsdom from 'jsdom';
 
-let namespace: Window & typeof globalThis;
+let namespace: Window & typeof globalThis & {
+    _jsdomReconfigure?: jsdom.JSDOM['reconfigure'];
+};
 if (typeof window !== 'undefined') {
     // browser
     namespace = window;
 } else if (typeof global !== 'undefined') {
     // node
-    namespace = new jsdom.JSDOM().window as unknown as Window & typeof globalThis;
+    const jsd = new jsdom.JSDOM();
+    namespace = jsd.window as unknown as Window & typeof globalThis;
+    namespace._jsdomReconfigure = jsd.reconfigure.bind(jsd);
 } else {
     // ¯\_(ツ)_/¯
     const throwPlatform = function() {

--- a/src/window.ts
+++ b/src/window.ts
@@ -1,7 +1,7 @@
 import jsdom from 'jsdom';
 
 let namespace: Window & typeof globalThis & {
-    _jsdomReconfigure?: jsdom.JSDOM['reconfigure'];
+    _jsdom?: jsdom.JSDOM;
 };
 if (typeof window !== 'undefined') {
     // browser
@@ -10,7 +10,7 @@ if (typeof window !== 'undefined') {
     // node
     const jsd = new jsdom.JSDOM();
     namespace = jsd.window as unknown as Window & typeof globalThis;
-    namespace._jsdomReconfigure = jsd.reconfigure.bind(jsd);
+    namespace._jsdom = jsd;
 } else {
     // ¯\_(ツ)_/¯
     const throwPlatform = function() {


### PR DESCRIPTION
This PR exposes JSDOM instance to userland when DNA is run from NodeJS environment. JSDOM instance is set as a property to the virtual Window object it creates.

Userland code can then access it like:

```js
import { window } from '@chialab/dna';

if (typeof window._jsdom !== 'undefined') {
  // We're using JSDOM implementation of Window.
  window._jsdom.reconfigure({ url: 'https://www.example.com/foo.html' });
}
```