### PR TITLE
Change the properties initialization in components

### DIFF
--- a/.changeset/kind-queens-tap.md
+++ b/.changeset/kind-queens-tap.md
@@ -1,0 +1,5 @@
+---
+"@chialab/dna": minor
+---
+
+Change the properties initialization in components

--- a/docs/API.md
+++ b/docs/API.md
@@ -1190,7 +1190,7 @@ The global DNA registry instance.
   attributeChangedCallback(attrName: string, oldValue: null | string, newValue: null | string): void;
   connectedCallback(): void;
   disconnectedCallback(): void
-} & <a href="#componentmixin">ComponentMixin</a>, P extends string | number | symbol&gt;(prototype: <a href="#withproperties">WithProperties</a>, propertyKey: <a href="#p">P</a>, declaration: <a href="#propertydeclaration">PropertyDeclaration</a>, symbolKey: symbol): <a href="#propertydescriptor">PropertyDescriptor</a></code>
+} & <a href="#componentmixin">ComponentMixin</a>, P extends string | number | symbol&gt;(prototype: <a href="#withproperties">WithProperties</a>, propertyKey: <a href="#p">P</a>, declaration: <a href="#propertydeclaration">PropertyDeclaration</a>, symbolKey: symbol, isStatic: boolean): <a href="#propertydescriptor">PropertyDescriptor</a></code>
 </summary>
 
 <strong>Params</strong>
@@ -1220,6 +1220,11 @@ The global DNA registry instance.
 <tr>
             <td>symbolKey</td>
             <td><code>symbol</code></td>
+            <td align="center"></td>
+            <td></td></tr>
+<tr>
+            <td>isStatic</td>
+            <td><code>boolean</code></td>
             <td align="center"></td>
             <td></td>
         </tr>

--- a/src/CustomElementRegistry.ts
+++ b/src/CustomElementRegistry.ts
@@ -1,6 +1,6 @@
 import type { Constructor } from './helpers';
 import { isConnected, connect, defineProperty, HTMLElementConstructor, document, nativeCustomElements } from './helpers';
-import { isComponent, isComponentConstructor, isConstructed } from './Component';
+import { isComponent, isComponentConstructor } from './Component';
 import { defineProperties } from './property';
 import { defineListeners } from './events';
 
@@ -237,9 +237,7 @@ export class CustomElementRegistry {
 
         // check if already instantiated
         if (isComponent(root)) {
-            if (isConstructed(root) && !root.slotChildNodes) {
-                root.forceUpdate();
-            }
+            root.forceUpdate();
             return;
         }
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -1,7 +1,7 @@
 import type { ClassElement, Constructor } from './helpers';
 import type { Members, ComponentConstructor, ComponentInstance, MethodsOf } from './Component';
 import { HTMLElementConstructor, isArray, defineProperty as _defineProperty, getOwnPropertyDescriptor, hasOwnProperty, getPrototypeOf } from './helpers';
-import { isComponent, isConstructed, isInitialized } from './Component';
+import { isComponent } from './Component';
 
 /**
  * A Symbol which contains all Property instances of a Component.
@@ -154,6 +154,10 @@ export type Property<T extends ComponentInstance, P extends keyof Members<T>>= P
      */
     readonly name: P;
     /**
+     * The property has been defined using static getter.
+     */
+    readonly static: boolean;
+    /**
      * The property private symbol.
      */
     symbol: symbol;
@@ -281,9 +285,10 @@ const extractTypes = <T extends ComponentInstance, P extends keyof PropertiesOf<
  * @param propertyKey The name of the property.
  * @param declaration The property descriptor.
  * @param symbolKey The symbol to use to store property value.
+ * @param isStatic The property definition is static.
  * @returns The final descriptor.
  */
-export const defineProperty = <T extends ComponentInstance, P extends keyof Members<T>>(prototype: WithProperties<T>, propertyKey: P, declaration: PropertyDeclaration<Constructor<T[P]>>, symbolKey: symbol): PropertyDescriptor => {
+export const defineProperty = <T extends ComponentInstance, P extends keyof Members<T>>(prototype: WithProperties<T>, propertyKey: P, declaration: PropertyDeclaration<Constructor<T[P]>>, symbolKey: symbol, isStatic = false): PropertyDescriptor => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const symbol: unique symbol = symbolKey as any;
     const hasAttribute = declaration.attribute || (declaration.attribute == null ? !declaration.state : false);
@@ -347,6 +352,7 @@ export const defineProperty = <T extends ComponentInstance, P extends keyof Memb
         attribute,
         event,
         update,
+        static: isStatic,
     } as Property<T, P>;
 
     const { get, set, getter, setter } = property;
@@ -368,7 +374,7 @@ export const defineProperty = <T extends ComponentInstance, P extends keyof Memb
             return value;
         },
         set(this: E, newValue) {
-            if (!isConstructed(this) || !isComponent(this)) {
+            if (!isComponent(this) || !this.watchedProperties.has(propertyKey)) {
                 this[symbol] = newValue;
                 return;
             }
@@ -423,7 +429,7 @@ export const defineProperty = <T extends ComponentInstance, P extends keyof Memb
                 this.propertyChangedCallback(propertyKey, oldValue, newValue);
             }
 
-            if (update && isInitialized(this)) {
+            if (update) {
                 this.forceUpdate();
             }
         },
@@ -468,7 +474,8 @@ export const defineProperties = <T extends ComponentInstance>(prototype: T) => {
                     prototype,
                     propertyKey,
                     declaration,
-                    symbol
+                    symbol,
+                    true
                 );
                 handled[propertyKey] = true;
             }

--- a/test/property.spec.js
+++ b/test/property.spec.js
@@ -96,8 +96,8 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
         });
 
         it('should define a property with single type checker', () => {
@@ -117,7 +117,8 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
+            const elem = new MyElement();
+            expect(() => elem.testProp = 42).to.throw(TypeError);
         });
 
         it('should define a property with multiple type checkers', () => {
@@ -137,9 +138,14 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement({ testProp: 'string' })).to.have.property('testProp', 'string');
-            expect(new MyElement({ testProp: true })).to.have.property('testProp', true);
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
+            const elem = new MyElement;
+            elem.testProp = 'string';
+            expect(elem).to.have.property('testProp', 'string');
+
+            elem.testProp = true;
+            expect(elem).to.have.property('testProp', true);
+
+            expect(() => elem.testProp = 42).to.throw(TypeError);
         });
 
         it('should define a property with custom validation', () => {
@@ -166,10 +172,15 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement({ testProp: 'string' })).to.have.property('testProp', 'string');
-            expect(new MyElement({ testProp: true })).to.have.property('testProp', true);
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
-            expect(() => new MyElement({ testProp: 'invalid' })).to.throw(TypeError);
+            const elem = new MyElement;
+            elem.testProp = 'string';
+            expect(elem).to.have.property('testProp', 'string');
+
+            elem.testProp = true;
+            expect(elem).to.have.property('testProp', true);
+
+            expect(() => elem.testProp = 42).to.throw(TypeError);
+            expect(() => elem.testProp = 'invalid').to.throw(TypeError);
         });
 
         it('should define a property with custom getter', () => {
@@ -191,8 +202,11 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 84);
-            expect(new MyElement({ testProp: 2 })).to.have.property('testProp', 4);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 84);
+
+            elem.testProp = 2;
+            expect(elem).to.have.property('testProp', 4);
         });
 
         it('should define a property with custom setter', () => {
@@ -215,8 +229,11 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
-            expect(new MyElement({ testProp: 2 })).to.have.property('testProp', 1);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
+
+            elem.testProp = 2;
+            expect(elem).to.have.property('testProp', 1);
         });
 
         it('should define a property with decorated accessor', () => {
@@ -242,8 +259,11 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 84);
-            expect(new MyElement({ testProp: 2 })).to.have.property('testProp', 4);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 84);
+
+            elem.testProp = 2;
+            expect(elem).to.have.property('testProp', 4);
         });
 
         it('should define a property with a single observer', () => {
@@ -265,9 +285,12 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener).to.have.been.called();
             expect(listener).to.have.been.called.with(42, 84, 'testProp');
         });
@@ -296,9 +319,12 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener).to.have.been.called();
             expect(listener).to.have.been.called.with(42, 84, 'testProp');
         });
@@ -341,11 +367,15 @@ describe('property', function() {
                 DNA.observe('testProp'),
             ], MyElement.prototype, 'listener2', undefined);
 
-            expect(new MyParent({ testProp: 84 })).to.have.property('testProp', 84);
+            const parent = new MyParent();
+            parent.testProp = 84;
+            expect(parent).to.have.property('testProp', 84);
             expect(listener).to.have.been.called();
             expect(listener2).to.not.have.been.called();
 
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+            const elem = new MyElement();
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener2).to.have.been.called();
         });
 
@@ -382,9 +412,12 @@ describe('property', function() {
                 };
             }, DNA.Component);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener).to.have.been.called();
             expect(listener).to.have.been.called.with(42, 84, 'testProp');
         });
@@ -409,10 +442,13 @@ describe('property', function() {
                 DNA.customElement(getComponentName()),
             ], MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener1).to.not.have.been.called();
             expect(listener2).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener1).to.have.been.called();
             expect(listener2).to.have.been.called();
             expect(listener1).to.have.been.called.with(42, 84, 'testProp');
@@ -448,8 +484,8 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
         });
 
         it('should define a property with single type checker', () => {
@@ -465,7 +501,8 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
+            const elem = new MyElement();
+            expect(() => elem.testProp = 42).to.throw(TypeError);
         });
 
         it('should define a property with multiple type checkers', () => {
@@ -481,9 +518,14 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement({ testProp: 'string' })).to.have.property('testProp', 'string');
-            expect(new MyElement({ testProp: true })).to.have.property('testProp', true);
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
+            const elem = new MyElement;
+            elem.testProp = 'string';
+            expect(elem).to.have.property('testProp', 'string');
+
+            elem.testProp = true;
+            expect(elem).to.have.property('testProp', true);
+
+            expect(() => elem.testProp = 42).to.throw(TypeError);
         });
 
         it('should define a property with custom validation', () => {
@@ -506,10 +548,15 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement({ testProp: 'string' })).to.have.property('testProp', 'string');
-            expect(new MyElement({ testProp: true })).to.have.property('testProp', true);
-            expect(() => new MyElement({ testProp: 42 })).to.throw(TypeError);
-            expect(() => new MyElement({ testProp: 'invalid' })).to.throw(TypeError);
+            const elem = new MyElement;
+            elem.testProp = 'string';
+            expect(elem).to.have.property('testProp', 'string');
+
+            elem.testProp = true;
+            expect(elem).to.have.property('testProp', true);
+
+            expect(() => elem.testProp = 42).to.throw(TypeError);
+            expect(() => elem.testProp = 'invalid').to.throw(TypeError);
         });
 
         it('should define a property with custom getter', () => {
@@ -528,8 +575,11 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 84);
-            expect(new MyElement({ testProp: 2 })).to.have.property('testProp', 4);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 84);
+
+            elem.testProp = 2;
+            expect(elem).to.have.property('testProp', 4);
         });
 
         it('should define a property with custom setter', () => {
@@ -549,8 +599,11 @@ describe('property', function() {
 
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
-            expect(new MyElement({ testProp: 2 })).to.have.property('testProp', 1);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
+
+            elem.testProp = 2;
+            expect(elem).to.have.property('testProp', 1);
         });
 
         it('should define a property with a single observer', () => {
@@ -568,9 +621,12 @@ describe('property', function() {
             };
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener).to.have.been.called();
             expect(listener).to.have.been.called.with(42, 84, 'testProp');
         });
@@ -591,10 +647,13 @@ describe('property', function() {
             };
             DNA.customElements.define(getComponentName(), MyElement);
 
-            expect(new MyElement()).to.have.property('testProp', 42);
+            const elem = new MyElement();
+            expect(elem).to.have.property('testProp', 42);
             expect(listener1).to.not.have.been.called();
             expect(listener2).to.not.have.been.called();
-            expect(new MyElement({ testProp: 84 })).to.have.property('testProp', 84);
+
+            elem.testProp = 84;
+            expect(elem).to.have.property('testProp', 84);
             expect(listener1).to.have.been.called();
             expect(listener2).to.have.been.called();
             expect(listener1).to.have.been.called.with(42, 84, 'testProp');


### PR DESCRIPTION
This PR solves a problem with properties initialization when a JS component constructor extends a TS constructor.