### PR TITLE
Collect slot children updates

### DIFF
--- a/.changeset/famous-tools-whisper.md
+++ b/.changeset/famous-tools-whisper.md
@@ -1,0 +1,5 @@
+---
+"@chialab/dna": minor
+---
+
+Collect slot children updates

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -497,7 +497,7 @@ const mixin = <T extends HTMLElement>(ctor: Constructor<T>) => {
                     element[propertyKey] = property.defaultValue;
                 }
                 if (property.static) {
-                    this.watchedProperties.push(propertyKey);
+                    element.watchedProperties.push(propertyKey);
                 }
             }
 

--- a/src/DOM.ts
+++ b/src/DOM.ts
@@ -83,9 +83,10 @@ export const DOM = {
      * @param parent The parent element.
      * @param newChild The child to add.
      * @param slot Should add a slot node.
+     * @param update Should invoke component update.
      * @returns The appended child.
      */
-    appendChild<T extends Node>(parent: Node, newChild: T, slot = isComponent(parent)): T {
+    appendChild<T extends Node>(parent: Node, newChild: T, slot = isComponent(parent), update = true): T {
         const oldParent = newChild.parentNode;
         const context = slot ? getHostContext(parent) as Context : getOrCreateContext(parent);
         if (slot) {
@@ -101,7 +102,9 @@ export const DOM = {
             if (!newChildContext.root) {
                 newChildContext.root = parent;
             }
-            (parent as ComponentInstance).forceUpdate();
+            if (update) {
+                (parent as ComponentInstance).forceUpdate();
+            }
             return newChild;
         }
         if (oldParent) {
@@ -121,9 +124,10 @@ export const DOM = {
      * @param parent The parent element.
      * @param oldChild The child to remove.
      * @param slot Should remove a slot node.
+     * @param update Should invoke component update.
      * @returns The removed child.
      */
-    removeChild<T extends Node>(parent: Node, oldChild: T, slot = isComponent(parent)): T {
+    removeChild<T extends Node>(parent: Node, oldChild: T, slot = isComponent(parent), update = true): T {
         const context = slot ? getHostContext(parent) as Context : getOrCreateContext(parent);
         if (slot) {
             const oldChildContext = getOrCreateContext(oldChild);
@@ -131,7 +135,9 @@ export const DOM = {
             const io = slotted.indexOf(oldChild);
             if (io !== -1) {
                 slotted.splice(io, 1);
-                (parent as ComponentInstance).forceUpdate();
+                if (update) {
+                    (parent as ComponentInstance).forceUpdate();
+                }
             }
             if (oldChildContext.root === parent) {
                 oldChildContext.root = undefined;
@@ -158,9 +164,10 @@ export const DOM = {
      * @param newChild The child to insert.
      * @param refChild The referred node.
      * @param slot Should insert a slot node.
+     * @param update Should invoke component update.
      * @returns The inserted child.
      */
-    insertBefore<T extends Node>(parent: Node, newChild: T, refChild: Node | null, slot = isComponent(parent)): T {
+    insertBefore<T extends Node>(parent: Node, newChild: T, refChild: Node | null, slot = isComponent(parent), update = true): T {
         const context = slot ? getHostContext(parent) as Context : getOrCreateContext(parent);
 
         if (slot) {
@@ -184,7 +191,9 @@ export const DOM = {
             if (!newChildContext.root) {
                 newChildContext.root = parent;
             }
-            (parent as ComponentInstance).forceUpdate();
+            if (update) {
+                (parent as ComponentInstance).forceUpdate();
+            }
             return newChild;
         }
 
@@ -217,9 +226,10 @@ export const DOM = {
      * @param newChild The child to insert.
      * @param oldChild The node to replace.
      * @param slot Should replace a slot node.
+     * @param update Should invoke component update.
      * @returns The replaced child.
      */
-    replaceChild<T extends Node>(parent: Node, newChild: Node, oldChild: T, slot = isComponent(parent)): T {
+    replaceChild<T extends Node>(parent: Node, newChild: Node, oldChild: T, slot = isComponent(parent), update = true): T {
         const context = slot ? getHostContext(parent) as Context : getOrCreateContext(parent);
         const parentNode = newChild.parentNode;
 
@@ -242,7 +252,9 @@ export const DOM = {
             if (!newChildContext.root) {
                 newChildContext.root = parent;
             }
-            (parent as ComponentInstance).forceUpdate();
+            if (update) {
+                (parent as ComponentInstance).forceUpdate();
+            }
             return oldChild;
         }
         if (parentNode && newChild !== oldChild) {
@@ -270,15 +282,16 @@ export const DOM = {
      * @param position The position of the insertion.
      * @param insertedElement The child to insert.
      * @param slot Should insert a slot node.
+     * @param update Should invoke component update.
      * @returns The inserted child.
      */
-    insertAdjacentElement(parent: Element, position: InsertPosition, insertedElement: Element, slot = isComponent(parent)): Element | null {
+    insertAdjacentElement(parent: Element, position: InsertPosition, insertedElement: Element, slot = isComponent(parent), update = true): Element | null {
         if (position === 'afterbegin') {
             const refChild = isComponent(parent) ? (parent.slotChildNodes as Node[])[0] : parent.firstChild;
-            return DOM.insertBefore(parent, insertedElement, refChild, slot);
+            return DOM.insertBefore(parent, insertedElement, refChild, slot, update);
         }
         if (position === 'beforeend') {
-            return DOM.insertBefore(parent, insertedElement, null, slot);
+            return DOM.insertBefore(parent, insertedElement, null, slot, update);
         }
 
         return insertAdjacentElementImpl.call(parent, position, insertedElement);

--- a/src/render.ts
+++ b/src/render.ts
@@ -624,13 +624,13 @@ const renderTemplate = (
         // remove nodes until the correct instance
         let currentContext: Context | null;
         while ((currentContext = getCurrentContext(context)) && (templateContext !== currentContext)) {
-            DOM.removeChild(parent, getCurrentNode(context), slot);
+            DOM.removeChild(parent, getCurrentNode(context), slot, false);
         }
 
         (context.currentIndex as number)++;
     } else {
         // we need to insert the new node into the tree
-        DOM.insertBefore(parent, templateNode, getCurrentNode(context), slot);
+        DOM.insertBefore(parent, templateNode, getCurrentNode(context), slot, false);
         (context.currentIndex as number)++;
     }
 
@@ -726,7 +726,7 @@ export const internalRender = (
         lastIndex = childNodes.length;
     }
     while (currentIndex < lastIndex) {
-        DOM.removeChild(parent, childNodes[--lastIndex], slot);
+        DOM.removeChild(parent, childNodes[--lastIndex], slot, false);
     }
 
     if (fragment) {
@@ -740,6 +740,10 @@ export const internalRender = (
         context.fragment = previousFragment;
         context.namespace = previousNamespace;
         context.currentIndex = previousIndex;
+    }
+
+    if (slot) {
+        (parent as ComponentInstance).forceUpdate();
     }
 
     return childNodes;


### PR DESCRIPTION
During render, multiple slot children of a component may change. This PR introduces an optimization to invoke the re-render of the component at the end of all DOM updates.